### PR TITLE
fix: bump kui to pick up removal of remark-code-frontmatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,20 +11,20 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/client": "file:./plugins/plugin-client-offline",
-        "@kui-shell/core": "13.0.0-dev-20230216-200003",
-        "@kui-shell/plugin-bash-like": "13.0.0-dev-20230216-200003",
-        "@kui-shell/plugin-carbon-themes": "13.0.0-dev-20230216-200003",
-        "@kui-shell/plugin-client-common": "13.0.0-dev-20230216-200003",
-        "@kui-shell/plugin-core-support": "13.0.0-dev-20230216-200003",
-        "@kui-shell/plugin-kubectl-core": "13.0.0-dev-20230216-200003",
-        "@kui-shell/plugin-patternfly4-themes": "13.0.0-dev-20230216-200003",
+        "@kui-shell/core": "13.1.1-dev-20230223-114029",
+        "@kui-shell/plugin-bash-like": "13.1.1-dev-20230223-114029",
+        "@kui-shell/plugin-carbon-themes": "13.1.1-dev-20230223-114029",
+        "@kui-shell/plugin-client-common": "13.1.1-dev-20230223-114029",
+        "@kui-shell/plugin-core-support": "13.1.1-dev-20230223-114029",
+        "@kui-shell/plugin-kubectl-core": "13.1.1-dev-20230223-114029",
+        "@kui-shell/plugin-patternfly4-themes": "13.1.1-dev-20230223-114029",
         "@kui-shell/plugin-tekton": "./plugins/plugin-tekton",
         "@kui-shell/plugin-wskflow": "./plugins/plugin-wskflow"
       },
       "devDependencies": {
-        "@kui-shell/builder": "13.0.0-dev-20230216-200003",
-        "@kui-shell/react": "13.0.0-dev-20230216-200003",
-        "@kui-shell/webpack": "13.0.0-dev-20230216-200003",
+        "@kui-shell/builder": "13.1.1-dev-20230223-114029",
+        "@kui-shell/react": "13.1.1-dev-20230223-114029",
+        "@kui-shell/webpack": "13.1.1-dev-20230223-114029",
         "@playwright/test": "^1.30.0",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
@@ -763,10 +763,11 @@
       }
     },
     "node_modules/@kui-shell/builder": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-SmRubJzwgyAc+p6xdzNfyf6qu0KMTou5kZ+bpbCbOrWtfGF4zbAvJoA8LAh7jUyog/bf+J+G8rr/KT619N+7VA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@babel/cli": "^7.20.7",
         "@babel/core": "^7.20.12",
@@ -793,8 +794,9 @@
       "link": true
     },
     "node_modules/@kui-shell/core": {
-      "version": "13.0.0-dev-20230216-200003",
-      "license": "Apache-2.0",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-38+e9dd2krizwODaC2FNhjCHg2UTJD7Sul+KlIWgPV4lkzS0okr2YDNZ0fEB9juabYw98Y1fL9kdHM0VNX45EQ==",
       "dependencies": {
         "colors": "^1.4.0",
         "columnify": "^1.6.0",
@@ -824,8 +826,9 @@
       }
     },
     "node_modules/@kui-shell/plugin-bash-like": {
-      "version": "13.0.0-dev-20230216-200003",
-      "license": "Apache-2.0",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-Ma8dcv2LZrAmra46LID5GFrS5gfGpDudqFS40cGJSHxFl1jiFsH7zLF1vdJFcLyLmWs6r78ZSRqGimkaNkQdVw==",
       "dependencies": {
         "@kui-shell/xterm-helpers": "^2.1.0",
         "cookie": "^0.5.0",
@@ -852,12 +855,14 @@
       }
     },
     "node_modules/@kui-shell/plugin-carbon-themes": {
-      "version": "13.0.0-dev-20230216-200003",
-      "license": "Apache-2.0"
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-carbon-themes/-/plugin-carbon-themes-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-g8GOCZ7V2p1sUIVmx0quolFCx4qDfPIRhu6W2MUUWfehmxz4nulEkreGzRs7Vb4NF0a6WP6cGJ47pfffJ1EaNQ=="
     },
     "node_modules/@kui-shell/plugin-client-common": {
-      "version": "13.0.0-dev-20230216-200003",
-      "license": "Apache-2.0",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-L1vtuQ4ElZDM9QFP7k+brEMUx7T4QO40cBqWS3ySj8mACqy1YHdgzdwthU8rAVSiF+OAOhJcVLmCrx3ntv4FSg==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@mdi/font": "^7.1.96",
@@ -867,13 +872,12 @@
         "anser": "^2.1.1",
         "ansi-regex": "^6.0.1",
         "entities": "^4.4.0",
-        "madwizard": "^6.1.2",
+        "madwizard": "^6.2.2",
         "monaco-editor": "^0.34.1",
         "monaco-editor-webpack-plugin": "^7.0.1",
         "react-markdown": "^8.0.5",
         "rehype-raw": "^6.1.1",
         "rehype-slug": "^5.1.0",
-        "remark-code-frontmatter": "^1.0.0",
         "remark-collapse": "^0.1.2",
         "remark-directive": "^2.0.1",
         "remark-emoji": "^3.1.0",
@@ -888,8 +892,9 @@
       }
     },
     "node_modules/@kui-shell/plugin-core-support": {
-      "version": "13.0.0-dev-20230216-200003",
-      "license": "Apache-2.0",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-IRGLzjEU60/TObjyo6HoqaEuETq+nIvKqLbFRB4pbwCKVZ7OkC0z1thTBsff7ZHef+8vNuCGG3003v+/EQKepA==",
       "dependencies": {
         "@supercharge/promise-pool": "^2.3.2",
         "debug": "^4.3.4",
@@ -897,12 +902,14 @@
       }
     },
     "node_modules/@kui-shell/plugin-kubectl-core": {
-      "version": "13.0.0-dev-20230216-200003",
-      "license": "Apache-2.0"
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-saiiAkAa8AplE/9LqyaWVopJPFIaCvGIp310SbBlgyjkFRLUkM7yqyZ2uRMkOuMHIqxI9IV99pkN5XoVojW3sQ=="
     },
     "node_modules/@kui-shell/plugin-patternfly4-themes": {
-      "version": "13.0.0-dev-20230216-200003",
-      "license": "Apache-2.0"
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-ZHRK0fw8ADrCtsnQ66BOMOEFSw6gl1b5N07XrqHg/85kTynM02mRgAEOYneq/ofwj3kPpeM6xjJHbcJ+8q3Nlg=="
     },
     "node_modules/@kui-shell/plugin-tekton": {
       "resolved": "plugins/plugin-tekton",
@@ -913,18 +920,20 @@
       "link": true
     },
     "node_modules/@kui-shell/react": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-pE2BgJBGz0fOHqk5bLcX2tf7cPVaxbrVUfTYasehewhptVV+r52KhFu9HYF4FOmNr/4gqIf9ZIVh4VQB/0wmyQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
     },
     "node_modules/@kui-shell/webpack": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-rC4XAMrlH07UwBT7JggdAiw4vszLCICxHL5a0QnQdk8AC/0MMubsyTWrvIK9MPTaitDTmTl4KVPVPLyh5PBVsQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
@@ -1045,7 +1054,8 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
+      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1055,7 +1065,8 @@
     },
     "node_modules/@npmcli/fs/node_modules/lru-cache": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1065,7 +1076,8 @@
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
       "version": "7.3.8",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1078,7 +1090,8 @@
     },
     "node_modules/@npmcli/fs/node_modules/yallist": {
       "version": "4.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@npmcli/move-file": {
       "version": "2.0.1",
@@ -1300,7 +1313,8 @@
     },
     "node_modules/@types/extend": {
       "version": "3.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -2567,7 +2581,8 @@
     },
     "node_modules/cacache": {
       "version": "17.0.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.0.4.tgz",
+      "integrity": "sha512-Z/nL3gU+zTUjz5pCA5vVjYM8pmaw2kxM7JEiE0fv3w77Wj+sFbi70CrBruUWH0uNcEdvLDixFpgA2JM4F4DBjA==",
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
@@ -2589,14 +2604,16 @@
     },
     "node_modules/cacache/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "8.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2612,15 +2629,17 @@
       }
     },
     "node_modules/cacache/node_modules/lru-cache": {
-      "version": "7.16.0",
-      "license": "ISC",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+      "integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/cacache/node_modules/minimatch": {
       "version": "5.1.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2738,7 +2757,8 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2746,7 +2766,8 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2754,7 +2775,8 @@
     },
     "node_modules/character-reference-invalid": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4155,7 +4177,8 @@
     },
     "node_modules/entities": {
       "version": "4.4.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
       "engines": {
         "node": ">=0.12"
       },
@@ -4469,7 +4492,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4588,7 +4612,8 @@
     },
     "node_modules/expand-home-dir": {
       "version": "0.0.3",
-      "license": "BSD"
+      "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
+      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA=="
     },
     "node_modules/express": {
       "version": "4.18.2",
@@ -4705,7 +4730,8 @@
     },
     "node_modules/fault": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
       "dependencies": {
         "format": "^0.2.0"
       },
@@ -4727,7 +4753,8 @@
     },
     "node_modules/figures": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "dependencies": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
@@ -4741,7 +4768,8 @@
     },
     "node_modules/figures/node_modules/escape-string-regexp": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "engines": {
         "node": ">=12"
       },
@@ -4914,6 +4942,8 @@
     },
     "node_modules/format": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
       }
@@ -4936,21 +4966,24 @@
     },
     "node_modules/front-matter": {
       "version": "4.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
       "dependencies": {
         "js-yaml": "^3.13.1"
       }
     },
     "node_modules/front-matter/node_modules/argparse": {
       "version": "1.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/front-matter/node_modules/js-yaml": {
       "version": "3.14.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4974,7 +5007,8 @@
     },
     "node_modules/fs-minipass": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.1.tgz",
+      "integrity": "sha512-MhaJDcFRTuLidHrIttu0RDGyyXs/IYHVmlcxfLAEFIWjc1vdLAkdwT7Ace2u7DbitWC0toKMl5eJZRYNVreIMw==",
       "dependencies": {
         "minipass": "^4.0.0"
       },
@@ -5306,7 +5340,8 @@
     },
     "node_modules/hast-util-embedded": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-2.0.1.tgz",
+      "integrity": "sha512-QUdSOP1/o+/TxXtpPFXR2mUg2P+ySrmlX7QjwHZCXqMFyYk7YmcGSvqRW+4XgXAoHifdE1t2PwFaQK33TqVjSw==",
       "dependencies": {
         "hast-util-is-element": "^2.0.0"
       },
@@ -5353,7 +5388,8 @@
     },
     "node_modules/hast-util-is-body-ok-link": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-2.0.0.tgz",
+      "integrity": "sha512-S58hCexyKdD31vMsErvgLfflW6vYWo/ixRLPJTtkOvLld24vyI8vmYmkgLA5LG3la2ME7nm7dLGdm48gfLRBfw==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "hast-util-has-property": "^2.0.0",
@@ -5366,7 +5402,8 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "2.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
+      "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0"
@@ -5389,7 +5426,8 @@
     },
     "node_modules/hast-util-phrasing": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-2.0.2.tgz",
+      "integrity": "sha512-yGkCfPkkfCyiLfK6KEl/orMDr/zgCnq/NaO9HfULx6/Zga5fso5eqQA5Ov/JZVqACygvw9shRYWgXNcG2ilo7w==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -5404,7 +5442,8 @@
     },
     "node_modules/hast-util-raw": {
       "version": "8.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-8.0.0.tgz",
+      "integrity": "sha512-bKbaUxMNLjZMMowgcrc4l3aQSPiMLiceZD+mp+AKF8Si0mtyR2DYVdxzS2XBxXYDeW/VvfZy40lNxHRiY6MMTg==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "extend": "^3.0.0",
@@ -5426,7 +5465,8 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "8.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
+      "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -5447,7 +5487,8 @@
     },
     "node_modules/hast-util-to-html/node_modules/hast-util-raw": {
       "version": "7.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
+      "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/parse5": "^6.0.0",
@@ -5468,11 +5509,13 @@
     },
     "node_modules/hast-util-to-html/node_modules/parse5": {
       "version": "6.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "node_modules/hast-util-to-mdast": {
       "version": "9.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-9.0.0.tgz",
+      "integrity": "sha512-7Pl4mWA3JCSHx0s3A1CgJaFirkISDUJsu+DeJd/cHUAlVDgs1sITzg9HZAidSf9LUE7kl8Hf2ZJr1HZTfhV/Yw==",
       "dependencies": {
         "@types/extend": "^3.0.0",
         "@types/hast": "^2.0.0",
@@ -5524,7 +5567,8 @@
     },
     "node_modules/hast-util-to-text": {
       "version": "3.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.2.tgz",
+      "integrity": "sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -5988,7 +6032,8 @@
     },
     "node_modules/install": {
       "version": "0.13.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -6014,7 +6059,8 @@
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6022,7 +6068,8 @@
     },
     "node_modules/is-alphanumerical": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
         "is-decimal": "^2.0.0"
@@ -6102,7 +6149,8 @@
     },
     "node_modules/is-decimal": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6166,7 +6214,8 @@
     },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6266,7 +6315,8 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "engines": {
         "node": ">=12"
       },
@@ -7019,13 +7069,14 @@
       }
     },
     "node_modules/madwizard": {
-      "version": "6.1.2",
-      "license": "Apache-2.0",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-6.2.2.tgz",
+      "integrity": "sha512-szhpyyWQjZXECLcs63ZISnW0x/QPESrGethSRPX3XXheleWUOZvytehzkM1dE42peeU0wJE4r0ujGEVB2OFpIA==",
       "dependencies": {
         "chalk": "^5.2.0",
         "columnify": "^1.6.0",
         "debug": "^4.3.4",
-        "enquirer": "https://git@github.com/starpit/enquirer#19b27f10d3304b4a3300b438592a004dc6ee1a7f",
+        "enquirer": "git+https://git@github.com/starpit/enquirer.git#19b27f10d3304b4a3300b438592a004dc6ee1a7f",
         "env-paths": "^2.2.1",
         "escalade": "^3.1.1",
         "expand-home-dir": "^0.0.3",
@@ -7065,7 +7116,8 @@
     },
     "node_modules/madwizard/node_modules/bl": {
       "version": "5.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -7074,7 +7126,8 @@
     },
     "node_modules/madwizard/node_modules/chalk": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7084,7 +7137,8 @@
     },
     "node_modules/madwizard/node_modules/cli-cursor": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -7097,7 +7151,8 @@
     },
     "node_modules/madwizard/node_modules/is-interactive": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "engines": {
         "node": ">=12"
       },
@@ -7107,7 +7162,8 @@
     },
     "node_modules/madwizard/node_modules/log-symbols": {
       "version": "5.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
       "dependencies": {
         "chalk": "^5.0.0",
         "is-unicode-supported": "^1.1.0"
@@ -7121,14 +7177,16 @@
     },
     "node_modules/madwizard/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/madwizard/node_modules/onetime": {
       "version": "5.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -7141,7 +7199,8 @@
     },
     "node_modules/madwizard/node_modules/ora": {
       "version": "6.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+      "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
       "dependencies": {
         "bl": "^5.0.0",
         "chalk": "^5.0.0",
@@ -7162,7 +7221,8 @@
     },
     "node_modules/madwizard/node_modules/restore-cursor": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -7176,7 +7236,8 @@
     },
     "node_modules/madwizard/node_modules/strip-ansi": {
       "version": "7.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -7209,7 +7270,8 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "11.0.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.0.3.tgz",
+      "integrity": "sha512-oPLh5m10lRNNZDjJ2kP8UpboUx2uFXVaVweVe/lWut4iHWcQEmfqSVJt2ihZsFI8HbpwyyocaXbCAWf0g1ukIA==",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^17.0.0",
@@ -7232,8 +7294,9 @@
       }
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "7.16.0",
-      "license": "ISC",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+      "integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
       "engines": {
         "node": ">=12"
       }
@@ -7271,7 +7334,8 @@
     },
     "node_modules/mdast-util-directive": {
       "version": "2.2.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-2.2.4.tgz",
+      "integrity": "sha512-sK3ojFP+jpj1n7Zo5ZKvoxP1MvLyzVG63+gm40Z/qI00avzdPCYxt7RBMgofwAva9gBjbDBWVRB/i+UD+fUCzQ==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -7334,7 +7398,8 @@
     },
     "node_modules/mdast-util-frontmatter": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
+      "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0",
@@ -7620,7 +7685,8 @@
     },
     "node_modules/micromark-extension-directive": {
       "version": "2.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-2.1.2.tgz",
+      "integrity": "sha512-brqLEztt14/73snVXYsq9Cv6ng67O+Sy69ZuM0s8ZhN/GFI9rnyXyj0Y0DaCwi648vCImv7/U1H5TzR7wMv5jw==",
       "dependencies": {
         "micromark-factory-space": "^1.0.0",
         "micromark-factory-whitespace": "^1.0.0",
@@ -7637,7 +7703,8 @@
     },
     "node_modules/micromark-extension-frontmatter": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-EXjmRnupoX6yYuUJSQhrQ9ggK0iQtQlpi6xeJzVD5xscyAI+giqco5fdymayZhJMbIFecjnE2yz85S9NzIgQpg==",
       "dependencies": {
         "fault": "^2.0.0",
         "micromark-util-character": "^1.0.0",
@@ -8238,7 +8305,8 @@
     },
     "node_modules/minipass-fetch": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.1.tgz",
+      "integrity": "sha512-t9/wowtf7DYkwz8cfMSt0rMwiyNIBXf5CKZ3S5ZMqRqMYT0oLTp0x1WorMI9WTwvaPg21r1JbFxJMum8JrLGfw==",
       "dependencies": {
         "minipass": "^4.0.0",
         "minipass-sized": "^1.0.3",
@@ -9245,7 +9313,8 @@
     },
     "node_modules/parse-entities": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
+      "integrity": "sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities": "^2.0.0",
@@ -9270,7 +9339,8 @@
     },
     "node_modules/parse5": {
       "version": "7.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -10373,7 +10443,8 @@
     },
     "node_modules/rehype-minify-whitespace": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.1.tgz",
+      "integrity": "sha512-PPp4lWJiBPlePI/dv1BeYktbwkfgXkrK59MUa+tYbMPgleod+4DvFK2PLU0O0O60/xuhHfiR9GUIUlXTU8sRIQ==",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -10450,57 +10521,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/remark-code-frontmatter": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "front-matter": "^3.0.2",
-        "unist-util-visit": "^1.4.1"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/argparse": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/front-matter": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "node_modules/remark-code-frontmatter/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/remark-code-frontmatter/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
-      }
-    },
     "node_modules/remark-collapse": {
       "version": "0.1.2",
       "license": "MIT",
@@ -10519,7 +10539,8 @@
     },
     "node_modules/remark-directive": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-2.0.1.tgz",
+      "integrity": "sha512-oosbsUAkU/qmUE78anLaJePnPis4ihsE7Agp0T/oqTzvTea8pOiaYEtfInU/+xMOVTS9PN5AhGOiaIVe4GD8gw==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-directive": "^2.0.0",
@@ -10545,7 +10566,8 @@
     },
     "node_modules/remark-frontmatter": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
+      "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-frontmatter": "^1.0.0",
@@ -11163,11 +11185,13 @@
     },
     "node_modules/shell-escape": {
       "version": "0.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+      "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw=="
     },
     "node_modules/shell-parser": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/shell-parser/-/shell-parser-1.0.0.tgz",
+      "integrity": "sha512-RBbMwEVcz+qaj99bzzDMAs/sqhwJS4RgC+PNBLaH1EaUo20ppp3iq4rh3hzplOrbzjDXt5wviIf0B7k9nTBAZA=="
     },
     "node_modules/shell-quote": {
       "version": "1.8.0",
@@ -11387,11 +11411,13 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/ssri": {
       "version": "10.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.1.tgz",
+      "integrity": "sha512-WVy6di9DlPOeBWEjMScpNipeSX2jIZBGEn5Uuo8Q7aIuFEuDX0pw8RxcOjlD1TWP4obi24ki7m/13+nFpcbXrw==",
       "dependencies": {
         "minipass": "^4.0.0"
       },
@@ -11509,7 +11535,8 @@
     },
     "node_modules/stringify-entities": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -11593,7 +11620,8 @@
     },
     "node_modules/supports-hyperlinks": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -11604,14 +11632,16 @@
     },
     "node_modules/supports-hyperlinks/node_modules/has-flag": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/supports-hyperlinks/node_modules/supports-color": {
       "version": "7.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11723,7 +11753,8 @@
     },
     "node_modules/terminal-link": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
+      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
       "dependencies": {
         "ansi-escapes": "^5.0.0",
         "supports-hyperlinks": "^2.2.0"
@@ -11737,7 +11768,8 @@
     },
     "node_modules/terminal-link/node_modules/ansi-escapes": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
       "dependencies": {
         "type-fest": "^1.0.2"
       },
@@ -11750,7 +11782,8 @@
     },
     "node_modules/terminal-link/node_modules/type-fest": {
       "version": "1.4.0",
-      "license": "(MIT OR CC0-1.0)",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
         "node": ">=10"
       },
@@ -11921,7 +11954,8 @@
     },
     "node_modules/to-vfile": {
       "version": "7.2.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.4.tgz",
+      "integrity": "sha512-2eQ+rJ2qGbyw3senPI0qjuM7aut8IYXK6AEoOWb+fJx/mQYzviTckm1wDjq91QYHAPBTYzmdJXxMFA6Mk14mdw==",
       "dependencies": {
         "is-buffer": "^2.0.0",
         "vfile": "^5.1.0"
@@ -11964,7 +11998,8 @@
     },
     "node_modules/trim-trailing-lines": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -12082,7 +12117,8 @@
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
       "dependencies": {
         "unique-slug": "^4.0.0"
       },
@@ -12092,7 +12128,8 @@
     },
     "node_modules/unique-slug": {
       "version": "4.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -12102,7 +12139,8 @@
     },
     "node_modules/unist-builder": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.1.tgz",
+      "integrity": "sha512-gnpOw7DIpCA0vpr6NqdPvTWnlPTApCTRzr+38E6hCWx3rz/cjo83SsKIlS1Z+L5ttScQ2AwutNnb8+tAvpb6qQ==",
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -12113,7 +12151,8 @@
     },
     "node_modules/unist-util-find-after": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
+      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -12692,7 +12731,8 @@
     },
     "node_modules/which": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -12840,7 +12880,8 @@
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -13489,7 +13530,9 @@
       }
     },
     "@kui-shell/builder": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-SmRubJzwgyAc+p6xdzNfyf6qu0KMTou5kZ+bpbCbOrWtfGF4zbAvJoA8LAh7jUyog/bf+J+G8rr/KT619N+7VA==",
       "dev": true,
       "requires": {
         "@babel/cli": "^7.20.7",
@@ -13506,7 +13549,9 @@
       "version": "file:plugins/plugin-client-offline"
     },
     "@kui-shell/core": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-38+e9dd2krizwODaC2FNhjCHg2UTJD7Sul+KlIWgPV4lkzS0okr2YDNZ0fEB9juabYw98Y1fL9kdHM0VNX45EQ==",
       "requires": {
         "colors": "^1.4.0",
         "columnify": "^1.6.0",
@@ -13531,7 +13576,9 @@
       }
     },
     "@kui-shell/plugin-bash-like": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-Ma8dcv2LZrAmra46LID5GFrS5gfGpDudqFS40cGJSHxFl1jiFsH7zLF1vdJFcLyLmWs6r78ZSRqGimkaNkQdVw==",
       "requires": {
         "@kui-shell/xterm-helpers": "^2.1.0",
         "cookie": "^0.5.0",
@@ -13556,10 +13603,14 @@
       }
     },
     "@kui-shell/plugin-carbon-themes": {
-      "version": "13.0.0-dev-20230216-200003"
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-carbon-themes/-/plugin-carbon-themes-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-g8GOCZ7V2p1sUIVmx0quolFCx4qDfPIRhu6W2MUUWfehmxz4nulEkreGzRs7Vb4NF0a6WP6cGJ47pfffJ1EaNQ=="
     },
     "@kui-shell/plugin-client-common": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-L1vtuQ4ElZDM9QFP7k+brEMUx7T4QO40cBqWS3ySj8mACqy1YHdgzdwthU8rAVSiF+OAOhJcVLmCrx3ntv4FSg==",
       "requires": {
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@mdi/font": "^7.1.96",
@@ -13569,13 +13620,12 @@
         "anser": "^2.1.1",
         "ansi-regex": "^6.0.1",
         "entities": "^4.4.0",
-        "madwizard": "^6.1.2",
+        "madwizard": "^6.2.2",
         "monaco-editor": "^0.34.1",
         "monaco-editor-webpack-plugin": "^7.0.1",
         "react-markdown": "^8.0.5",
         "rehype-raw": "^6.1.1",
         "rehype-slug": "^5.1.0",
-        "remark-code-frontmatter": "^1.0.0",
         "remark-collapse": "^0.1.2",
         "remark-directive": "^2.0.1",
         "remark-emoji": "^3.1.0",
@@ -13590,7 +13640,9 @@
       }
     },
     "@kui-shell/plugin-core-support": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-IRGLzjEU60/TObjyo6HoqaEuETq+nIvKqLbFRB4pbwCKVZ7OkC0z1thTBsff7ZHef+8vNuCGG3003v+/EQKepA==",
       "requires": {
         "@supercharge/promise-pool": "^2.3.2",
         "debug": "^4.3.4",
@@ -13598,10 +13650,14 @@
       }
     },
     "@kui-shell/plugin-kubectl-core": {
-      "version": "13.0.0-dev-20230216-200003"
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-saiiAkAa8AplE/9LqyaWVopJPFIaCvGIp310SbBlgyjkFRLUkM7yqyZ2uRMkOuMHIqxI9IV99pkN5XoVojW3sQ=="
     },
     "@kui-shell/plugin-patternfly4-themes": {
-      "version": "13.0.0-dev-20230216-200003"
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-ZHRK0fw8ADrCtsnQ66BOMOEFSw6gl1b5N07XrqHg/85kTynM02mRgAEOYneq/ofwj3kPpeM6xjJHbcJ+8q3Nlg=="
     },
     "@kui-shell/plugin-tekton": {
       "version": "file:plugins/plugin-tekton"
@@ -13618,7 +13674,9 @@
       }
     },
     "@kui-shell/react": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-pE2BgJBGz0fOHqk5bLcX2tf7cPVaxbrVUfTYasehewhptVV+r52KhFu9HYF4FOmNr/4gqIf9ZIVh4VQB/0wmyQ==",
       "dev": true,
       "requires": {
         "react": "^18.2.0",
@@ -13626,7 +13684,9 @@
       }
     },
     "@kui-shell/webpack": {
-      "version": "13.0.0-dev-20230216-200003",
+      "version": "13.1.1-dev-20230223-114029",
+      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.1.1-dev-20230223-114029.tgz",
+      "integrity": "sha512-rC4XAMrlH07UwBT7JggdAiw4vszLCICxHL5a0QnQdk8AC/0MMubsyTWrvIK9MPTaitDTmTl4KVPVPLyh5PBVsQ==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",
@@ -13712,24 +13772,32 @@
     },
     "@npmcli/fs": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
+      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
       "requires": {
         "semver": "^7.3.5"
       },
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -13890,7 +13958,9 @@
       }
     },
     "@types/extend": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
     },
     "@types/hast": {
       "version": "2.3.4",
@@ -14723,6 +14793,8 @@
     },
     "cacache": {
       "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.0.4.tgz",
+      "integrity": "sha512-Z/nL3gU+zTUjz5pCA5vVjYM8pmaw2kxM7JEiE0fv3w77Wj+sFbi70CrBruUWH0uNcEdvLDixFpgA2JM4F4DBjA==",
       "requires": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
@@ -14741,12 +14813,16 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "glob": {
           "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -14756,10 +14832,14 @@
           }
         },
         "lru-cache": {
-          "version": "7.16.0"
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+          "integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ=="
         },
         "minimatch": {
           "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -14832,13 +14912,19 @@
       "version": "2.0.2"
     },
     "character-entities-html4": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
     },
     "character-entities-legacy": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
     },
     "character-reference-invalid": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
     },
     "chokidar": {
       "version": "3.5.3",
@@ -15700,7 +15786,9 @@
       }
     },
     "entities": {
-      "version": "4.4.0"
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "env-paths": {
       "version": "2.2.1"
@@ -15885,7 +15973,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -15955,7 +16045,9 @@
       }
     },
     "expand-home-dir": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
+      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA=="
     },
     "express": {
       "version": "4.18.2",
@@ -16050,6 +16142,8 @@
     },
     "fault": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
       "requires": {
         "format": "^0.2.0"
       }
@@ -16063,13 +16157,17 @@
     },
     "figures": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "requires": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "5.0.0"
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
         }
       }
     },
@@ -16175,7 +16273,9 @@
       }
     },
     "format": {
-      "version": "0.2.2"
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="
     },
     "forwarded": {
       "version": "0.2.0",
@@ -16187,18 +16287,24 @@
     },
     "front-matter": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
       "requires": {
         "js-yaml": "^3.13.1"
       },
       "dependencies": {
         "argparse": {
           "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "requires": {
             "sprintf-js": "~1.0.2"
           }
         },
         "js-yaml": {
           "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -16217,6 +16323,8 @@
     },
     "fs-minipass": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.1.tgz",
+      "integrity": "sha512-MhaJDcFRTuLidHrIttu0RDGyyXs/IYHVmlcxfLAEFIWjc1vdLAkdwT7Ace2u7DbitWC0toKMl5eJZRYNVreIMw==",
       "requires": {
         "minipass": "^4.0.0"
       }
@@ -16431,6 +16539,8 @@
     },
     "hast-util-embedded": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-2.0.1.tgz",
+      "integrity": "sha512-QUdSOP1/o+/TxXtpPFXR2mUg2P+ySrmlX7QjwHZCXqMFyYk7YmcGSvqRW+4XgXAoHifdE1t2PwFaQK33TqVjSw==",
       "requires": {
         "hast-util-is-element": "^2.0.0"
       }
@@ -16458,6 +16568,8 @@
     },
     "hast-util-is-body-ok-link": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-2.0.0.tgz",
+      "integrity": "sha512-S58hCexyKdD31vMsErvgLfflW6vYWo/ixRLPJTtkOvLld24vyI8vmYmkgLA5LG3la2ME7nm7dLGdm48gfLRBfw==",
       "requires": {
         "@types/hast": "^2.0.0",
         "hast-util-has-property": "^2.0.0",
@@ -16466,6 +16578,8 @@
     },
     "hast-util-is-element": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
+      "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0"
@@ -16479,6 +16593,8 @@
     },
     "hast-util-phrasing": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-2.0.2.tgz",
+      "integrity": "sha512-yGkCfPkkfCyiLfK6KEl/orMDr/zgCnq/NaO9HfULx6/Zga5fso5eqQA5Ov/JZVqACygvw9shRYWgXNcG2ilo7w==",
       "requires": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -16489,6 +16605,8 @@
     },
     "hast-util-raw": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-8.0.0.tgz",
+      "integrity": "sha512-bKbaUxMNLjZMMowgcrc4l3aQSPiMLiceZD+mp+AKF8Si0mtyR2DYVdxzS2XBxXYDeW/VvfZy40lNxHRiY6MMTg==",
       "requires": {
         "@types/hast": "^2.0.0",
         "extend": "^3.0.0",
@@ -16506,6 +16624,8 @@
     },
     "hast-util-to-html": {
       "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
+      "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -16522,6 +16642,8 @@
       "dependencies": {
         "hast-util-raw": {
           "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
+          "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
           "requires": {
             "@types/hast": "^2.0.0",
             "@types/parse5": "^6.0.0",
@@ -16537,12 +16659,16 @@
           }
         },
         "parse5": {
-          "version": "6.0.1"
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
         }
       }
     },
     "hast-util-to-mdast": {
       "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-9.0.0.tgz",
+      "integrity": "sha512-7Pl4mWA3JCSHx0s3A1CgJaFirkISDUJsu+DeJd/cHUAlVDgs1sITzg9HZAidSf9LUE7kl8Hf2ZJr1HZTfhV/Yw==",
       "requires": {
         "@types/extend": "^3.0.0",
         "@types/hast": "^2.0.0",
@@ -16580,6 +16706,8 @@
     },
     "hast-util-to-text": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.2.tgz",
+      "integrity": "sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -16869,7 +16997,9 @@
       "version": "0.1.1"
     },
     "install": {
-      "version": "0.13.0"
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA=="
     },
     "interpret": {
       "version": "1.4.0"
@@ -16882,10 +17012,14 @@
       "dev": true
     },
     "is-alphabetical": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
     },
     "is-alphanumerical": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
       "requires": {
         "is-alphabetical": "^2.0.0",
         "is-decimal": "^2.0.0"
@@ -16920,7 +17054,9 @@
       }
     },
     "is-decimal": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
     },
     "is-docker": {
       "version": "2.2.1",
@@ -16947,7 +17083,9 @@
       }
     },
     "is-hexadecimal": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
     },
     "is-interactive": {
       "version": "1.0.0",
@@ -16997,7 +17135,9 @@
       }
     },
     "is-unicode-supported": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -17458,12 +17598,14 @@
       }
     },
     "madwizard": {
-      "version": "6.1.2",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-6.2.2.tgz",
+      "integrity": "sha512-szhpyyWQjZXECLcs63ZISnW0x/QPESrGethSRPX3XXheleWUOZvytehzkM1dE42peeU0wJE4r0ujGEVB2OFpIA==",
       "requires": {
         "chalk": "^5.2.0",
         "columnify": "^1.6.0",
         "debug": "^4.3.4",
-        "enquirer": "https://git@github.com/starpit/enquirer#19b27f10d3304b4a3300b438592a004dc6ee1a7f",
+        "enquirer": "git+https://git@github.com/starpit/enquirer.git#19b27f10d3304b4a3300b438592a004dc6ee1a7f",
         "env-paths": "^2.2.1",
         "escalade": "^3.1.1",
         "expand-home-dir": "^0.0.3",
@@ -17503,6 +17645,8 @@
       "dependencies": {
         "bl": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
           "requires": {
             "buffer": "^6.0.3",
             "inherits": "^2.0.4",
@@ -17510,35 +17654,49 @@
           }
         },
         "chalk": {
-          "version": "5.2.0"
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
         },
         "cli-cursor": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
           "requires": {
             "restore-cursor": "^4.0.0"
           }
         },
         "is-interactive": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+          "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
         },
         "log-symbols": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+          "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
           "requires": {
             "chalk": "^5.0.0",
             "is-unicode-supported": "^1.1.0"
           }
         },
         "mimic-fn": {
-          "version": "2.1.0"
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "onetime": {
           "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
           "requires": {
             "mimic-fn": "^2.1.0"
           }
         },
         "ora": {
           "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+          "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
           "requires": {
             "bl": "^5.0.0",
             "chalk": "^5.0.0",
@@ -17553,6 +17711,8 @@
         },
         "restore-cursor": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+          "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
           "requires": {
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
@@ -17560,6 +17720,8 @@
         },
         "strip-ansi": {
           "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
           "requires": {
             "ansi-regex": "^6.0.1"
           }
@@ -17582,6 +17744,8 @@
     },
     "make-fetch-happen": {
       "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.0.3.tgz",
+      "integrity": "sha512-oPLh5m10lRNNZDjJ2kP8UpboUx2uFXVaVweVe/lWut4iHWcQEmfqSVJt2ihZsFI8HbpwyyocaXbCAWf0g1ukIA==",
       "requires": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^17.0.0",
@@ -17601,7 +17765,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.16.0"
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+          "integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ=="
         }
       }
     },
@@ -17627,6 +17793,8 @@
     },
     "mdast-util-directive": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-2.2.4.tgz",
+      "integrity": "sha512-sK3ojFP+jpj1n7Zo5ZKvoxP1MvLyzVG63+gm40Z/qI00avzdPCYxt7RBMgofwAva9gBjbDBWVRB/i+UD+fUCzQ==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",
@@ -17670,6 +17838,8 @@
     },
     "mdast-util-frontmatter": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-1.0.1.tgz",
+      "integrity": "sha512-JjA2OjxRqAa8wEG8hloD0uTU0kdn8kbtOWpPP94NBkfAlbxn4S8gCGf/9DwFtEeGPXrDcNXdiDjVaRdUFqYokw==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0",
@@ -17852,6 +18022,8 @@
     },
     "micromark-extension-directive": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-2.1.2.tgz",
+      "integrity": "sha512-brqLEztt14/73snVXYsq9Cv6ng67O+Sy69ZuM0s8ZhN/GFI9rnyXyj0Y0DaCwi648vCImv7/U1H5TzR7wMv5jw==",
       "requires": {
         "micromark-factory-space": "^1.0.0",
         "micromark-factory-whitespace": "^1.0.0",
@@ -17864,6 +18036,8 @@
     },
     "micromark-extension-frontmatter": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-1.0.0.tgz",
+      "integrity": "sha512-EXjmRnupoX6yYuUJSQhrQ9ggK0iQtQlpi6xeJzVD5xscyAI+giqco5fdymayZhJMbIFecjnE2yz85S9NzIgQpg==",
       "requires": {
         "fault": "^2.0.0",
         "micromark-util-character": "^1.0.0",
@@ -18155,6 +18329,8 @@
     },
     "minipass-fetch": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.1.tgz",
+      "integrity": "sha512-t9/wowtf7DYkwz8cfMSt0rMwiyNIBXf5CKZ3S5ZMqRqMYT0oLTp0x1WorMI9WTwvaPg21r1JbFxJMum8JrLGfw==",
       "requires": {
         "encoding": "^0.1.13",
         "minipass": "^4.0.0",
@@ -18798,6 +18974,8 @@
     },
     "parse-entities": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
+      "integrity": "sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==",
       "requires": {
         "@types/unist": "^2.0.0",
         "character-entities": "^2.0.0",
@@ -18814,6 +18992,8 @@
     },
     "parse5": {
       "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "requires": {
         "entities": "^4.4.0"
       }
@@ -19440,6 +19620,8 @@
     },
     "rehype-minify-whitespace": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.1.tgz",
+      "integrity": "sha512-PPp4lWJiBPlePI/dv1BeYktbwkfgXkrK59MUa+tYbMPgleod+4DvFK2PLU0O0O60/xuhHfiR9GUIUlXTU8sRIQ==",
       "requires": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -19494,49 +19676,6 @@
       "version": "0.2.7",
       "dev": true
     },
-    "remark-code-frontmatter": {
-      "version": "1.0.0",
-      "requires": {
-        "front-matter": "^3.0.2",
-        "unist-util-visit": "^1.4.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "front-matter": {
-          "version": "3.2.1",
-          "requires": {
-            "js-yaml": "^3.13.1"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "unist-util-is": {
-          "version": "3.0.0"
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        }
-      }
-    },
     "remark-collapse": {
       "version": "0.1.2",
       "requires": {
@@ -19551,6 +19690,8 @@
     },
     "remark-directive": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-2.0.1.tgz",
+      "integrity": "sha512-oosbsUAkU/qmUE78anLaJePnPis4ihsE7Agp0T/oqTzvTea8pOiaYEtfInU/+xMOVTS9PN5AhGOiaIVe4GD8gw==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-directive": "^2.0.0",
@@ -19568,6 +19709,8 @@
     },
     "remark-frontmatter": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-4.0.1.tgz",
+      "integrity": "sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-frontmatter": "^1.0.0",
@@ -19954,10 +20097,14 @@
       "dev": true
     },
     "shell-escape": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+      "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw=="
     },
     "shell-parser": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shell-parser/-/shell-parser-1.0.0.tgz",
+      "integrity": "sha512-RBbMwEVcz+qaj99bzzDMAs/sqhwJS4RgC+PNBLaH1EaUo20ppp3iq4rh3hzplOrbzjDXt5wviIf0B7k9nTBAZA=="
     },
     "shell-quote": {
       "version": "1.8.0",
@@ -20094,10 +20241,14 @@
       "version": "2.0.1"
     },
     "sprintf-js": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "ssri": {
       "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.1.tgz",
+      "integrity": "sha512-WVy6di9DlPOeBWEjMScpNipeSX2jIZBGEn5Uuo8Q7aIuFEuDX0pw8RxcOjlD1TWP4obi24ki7m/13+nFpcbXrw==",
       "requires": {
         "minipass": "^4.0.0"
       }
@@ -20182,6 +20333,8 @@
     },
     "stringify-entities": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
       "requires": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -20229,16 +20382,22 @@
     },
     "supports-hyperlinks": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       },
       "dependencies": {
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -20312,6 +20471,8 @@
     },
     "terminal-link": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
+      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
       "requires": {
         "ansi-escapes": "^5.0.0",
         "supports-hyperlinks": "^2.2.0"
@@ -20319,12 +20480,16 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+          "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
           "requires": {
             "type-fest": "^1.0.2"
           }
         },
         "type-fest": {
-          "version": "1.4.0"
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
@@ -20422,6 +20587,8 @@
     },
     "to-vfile": {
       "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.4.tgz",
+      "integrity": "sha512-2eQ+rJ2qGbyw3senPI0qjuM7aut8IYXK6AEoOWb+fJx/mQYzviTckm1wDjq91QYHAPBTYzmdJXxMFA6Mk14mdw==",
       "requires": {
         "is-buffer": "^2.0.0",
         "vfile": "^5.1.0"
@@ -20445,7 +20612,9 @@
       "version": "3.0.1"
     },
     "trim-trailing-lines": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg=="
     },
     "trough": {
       "version": "2.1.0"
@@ -20516,24 +20685,32 @@
     },
     "unique-filename": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
       "requires": {
         "unique-slug": "^4.0.0"
       }
     },
     "unique-slug": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
       "requires": {
         "imurmurhash": "^0.1.4"
       }
     },
     "unist-builder": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.1.tgz",
+      "integrity": "sha512-gnpOw7DIpCA0vpr6NqdPvTWnlPTApCTRzr+38E6hCWx3rz/cjo83SsKIlS1Z+L5ttScQ2AwutNnb8+tAvpb6qQ==",
       "requires": {
         "@types/unist": "^2.0.0"
       }
     },
     "unist-util-find-after": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
+      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -20861,6 +21038,8 @@
     },
     "which": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -20955,6 +21134,8 @@
     },
     "write-file-atomic": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
+      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
       "requires": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "printWidth": 120
   },
   "devDependencies": {
-    "@kui-shell/builder": "13.0.0-dev-20230216-200003",
-    "@kui-shell/react": "13.0.0-dev-20230216-200003",
-    "@kui-shell/webpack": "13.0.0-dev-20230216-200003",
+    "@kui-shell/builder": "13.1.1-dev-20230223-114029",
+    "@kui-shell/react": "13.1.1-dev-20230223-114029",
+    "@kui-shell/webpack": "13.1.1-dev-20230223-114029",
     "@playwright/test": "^1.30.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
@@ -78,13 +78,13 @@
   },
   "dependencies": {
     "@kui-shell/client": "file:./plugins/plugin-client-offline",
-    "@kui-shell/core": "13.0.0-dev-20230216-200003",
-    "@kui-shell/plugin-bash-like": "13.0.0-dev-20230216-200003",
-    "@kui-shell/plugin-carbon-themes": "13.0.0-dev-20230216-200003",
-    "@kui-shell/plugin-client-common": "13.0.0-dev-20230216-200003",
-    "@kui-shell/plugin-core-support": "13.0.0-dev-20230216-200003",
-    "@kui-shell/plugin-patternfly4-themes": "13.0.0-dev-20230216-200003",
-    "@kui-shell/plugin-kubectl-core": "13.0.0-dev-20230216-200003",
+    "@kui-shell/core": "13.1.1-dev-20230223-114029",
+    "@kui-shell/plugin-bash-like": "13.1.1-dev-20230223-114029",
+    "@kui-shell/plugin-carbon-themes": "13.1.1-dev-20230223-114029",
+    "@kui-shell/plugin-client-common": "13.1.1-dev-20230223-114029",
+    "@kui-shell/plugin-core-support": "13.1.1-dev-20230223-114029",
+    "@kui-shell/plugin-patternfly4-themes": "13.1.1-dev-20230223-114029",
+    "@kui-shell/plugin-kubectl-core": "13.1.1-dev-20230223-114029",
     "@kui-shell/plugin-tekton": "./plugins/plugin-tekton",
     "@kui-shell/plugin-wskflow": "./plugins/plugin-wskflow"
   }


### PR DESCRIPTION
This should eliminate the vulnerability on an old `front-matter` npm